### PR TITLE
Prefer const over define

### DIFF
--- a/snippets/hack.json
+++ b/snippets/hack.json
@@ -32,7 +32,11 @@
       "prefix": "trait",
       "body": "/**\n * $1\n */\ntrait ${2:TraitName}\n{\n\tfunction ${3:functionName}(${4:argument})\n\t{\n\t\t${5:# code...}\n\t}\n}\n"
     },
-    "define(…, …)": {
+    "const _ _ = _": {
+      "prefix" "const",
+      "body": "const ${1: type} ${2: name} = ${3: value};$0"
+    },
+    "define(…, …) >> Prefer const": {
       "prefix": "def",
       "body": "define('$1', ${2:'$3'});\n$0"
     },


### PR DESCRIPTION
`define('constname', 'value')` is very PHP-ish.
Added a `const type name = value;` snippet.